### PR TITLE
clear local storage after initialling page

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -164,6 +164,9 @@ server.onPhantomPageCreate = function(req, res) {
 
     req.prerender.page.set('libraryPath', __dirname + '/injections');
     req.prerender.page.set('onInitialized', function(){
+      req.prerender.page.evaluate(function(){
+        localStorage.clear();
+      });
       if(!process.env.DISABLE_INJECTION && req.prerender.page) req.prerender.page.injectJs('bind.js');
     });
 
@@ -423,7 +426,7 @@ server._send = function(req, res, statusCode, options) {
                 res.setHeader(header.name, header.value);
             });
         }
-        
+
         if (req.prerender.redirectURL && !(_this.options.followRedirect || process.env.FOLLOW_REDIRECT)) {
             res.setHeader('Location', req.prerender.redirectURL);
         }

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ var server = prerender({
 // server.use(prerender.basicAuth());
 // server.use(prerender.whitelist());
 server.use(prerender.blacklist());
-// server.use(prerender.logger());
+server.use(prerender.logger());
 server.use(prerender.removeScriptTags());
 server.use(prerender.httpHeaders());
 // server.use(prerender.inMemoryHtmlCache());


### PR DESCRIPTION
@sofish @YanagiEiichi 
之前用的是一个插件 https://github.com/hightail/prerender-clear-local-storage ，他清除local storage的方式是直接去清空存储的文件，并且每个请求都重启phantomjs。导致线上目前及其不稳定，现在改成在页面初始化后`localStorage.clear();`的方式，你们看是否ok。
ps:不知道node包什么的怎么玩，所以直接fork过来改了源码。